### PR TITLE
perf(package): reduce bundle size by 99.2%

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "chalk": "^2.4.2",
-    "eslint-config-kentcdodds": "^14.3.2",
     "pegjs": "^0.10.0"
   },
   "devDependencies": {
+    "eslint-config-kentcdodds": "^14.3.2",
     "@semantic-release/changelog": "^3.0.1",
     "@semantic-release/git": "^7.0.5",
     "@semantic-release/npm": "^5.1.7",


### PR DESCRIPTION
This package is [24.6Mb](https://packagephobia.now.sh/result?p=json-fixer)
99.2% of that is [eslint-config-kentcdodds](https://packagephobia.now.sh/result?p=eslint-config-kentcdodds) and I believe it can be moved to a devDependency


and since you seem to be a fan of badges :smile:, consider adding this one! [![install size](https://packagephobia.now.sh/badge?p=json-fixer)](https://packagephobia.now.sh/result?p=json-fixer)
